### PR TITLE
update the stepdefinition of the 'open ocm portal'

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -87,7 +87,7 @@ environments:
   ose: *ocp4
   ocm_stage:
     hosts: cloud.redhat.com:etcd:master:node
-    web_console_url: https://cloud.redhat.com
+    web_console_url: https://cloud.redhat.com/beta
     type: StaticEnvironment
     ocm_env: stage
   ocm_prod:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -85,6 +85,16 @@ environments:
     api_port: 6443
     version: 4.1.0.0 # version not supported on cluster (yet)
   ose: *ocp4
+  ocm_stage:
+    hosts: cloud.redhat.com:etcd:master:node
+    web_console_url: https://cloud.redhat.com
+    type: StaticEnvironment
+    ocm_env: stage
+  ocm_prod:
+    hosts: cloud.redhat.com:etcd:master:node
+    web_console_url: https://cloud.redhat.com
+    type: StaticEnvironment
+    ocm_env: product
 
 optional_classes:
   tcms_tc_manager:

--- a/features/step_definitions/ocm.rb
+++ b/features/step_definitions/ocm.rb
@@ -1,16 +1,20 @@
-Given /^I open ocm #{WORD} portal with #{WORD}$/ do |envi, usertype|
-  base_rules = BushSlicer::WebConsoleExecutor::RULES_DIR + "/base/"
+Given /^I open ocm portal with #{WORD}$/ do |usertype|
+  base_rules = BushSlicer::WebConsoleExecutor::RULES_DIR
   snippets_dir = BushSlicer::WebConsoleExecutor::SNIPPETS_DIR
   portals = YAML.load_file(expand_private_path("config/credentials/ocm.yaml"))
-  portal_name = envi
-  base_url = portals[portal_name]["url"]
+  ocm_env = env.ocm_env
+  base_url = env.web_console_url
   step "I have a browser with:", table(%{
-    | rules        | #{base_rules}                      |
     | rules        | lib/rules/web/ocm_console/  |
     | base_url     | #{base_url}       |
     | snippets_dir | #{snippets_dir}                    |
   })
-  @result = browser.run_action(:login_ocm_stage_console,
-                               username: portals[portal_name]["users"][usertype]["username"],
-                               password: portals[portal_name]["users"][usertype]["password"])
+  if ocm_env == "stage"
+    browser.run_action(:goto_ocm_stage_console)
+  elsif ocm_env == "product"
+    browser.run_action(:goto_ocm_prod_console)
+  end
+  @result = browser.run_action(:login_ocm_sequence,
+                               username: portals[ocm_env]["users"][usertype]["username"],
+                               password: portals[ocm_env]["users"][usertype]["password"])
 end

--- a/lib/environment.rb
+++ b/lib/environment.rb
@@ -165,6 +165,17 @@ module BushSlicer
       return @idp
     end
 
+    def ocm_env
+      unless @ocm_env
+        if opts[:ocm_env]
+          @ocm_env = opts[:ocm_env]
+        else
+          @ocm_env = ''
+        end
+      end
+      return @ocm_env
+    end
+
     def authentication_url
       unless @authentication_url
         if opts[:authentication_url]

--- a/lib/rules/web/ocm_console/login.xyaml
+++ b/lib/rules/web/ocm_console/login.xyaml
@@ -1,6 +1,7 @@
-login_ocm_stage_console:
+goto_ocm_stage_console:
   url: /beta/openshift
-  action: login_ocm_sequence
+goto_ocm_prod_console:
+  url: /openshift
 login_ocm_sequence:
   action: login_ocm_page_loaded
   action: login_ocm_portal


### PR DESCRIPTION
updated the 'I open ocm portal with' step definition and some env config.
For OCM testing, there are two envs can be used,ocm_stage and ocm_prod, the config is in the config.yaml.
We need to export BUSHSLICER_DEFAULT_ENVIRONMENT as one of the envs when we test locally.