### PR TITLE
WIP: Update ocm_console `click_logout_button` selectors

### DIFF
--- a/lib/rules/web/ocm_console/cluster_list_page.xyaml
+++ b/lib/rules/web/ocm_console/cluster_list_page.xyaml
@@ -380,11 +380,11 @@ go_to_access_control_tab:
 click_logout_button:
   element:
     selector:
-      xpath: //div[@class='pf-c-dropdown']/button/span[contains(., 'UItesting')]/../../button
+      xpath: //div[@widget-type="InsightsOverflowActions"]//button[@aria-label="Actions"]
     op: click
   element:
     selector:
-      xpath: //button[@class='pf-c-dropdown__menu-item' and text()='Logout']
+      xpath: //div[@widget-type="InsightsOverflowActions"]//button[text()='Logout']
     op: click
     timeout: 20
 logout_page_loaded:


### PR DESCRIPTION
~~I'm not sure where the `UItesting` was supposed to come from.  The dropdown class doesn't exist now either.
Maybe it predates switch from uhc-portal implementing header to insights-chrome(?), but can't find that string anywhere in uhc-portal & insights-chrome git histories.~~  UPDATE: see below, it's "last name" of QE's test users.  

Replaced selectors with ones that work with my user on current insights-chrome menu (implemented [here](https://github.com/RedHatInsights/insights-chrome/blob/f3fb33bcf67fd02410ea64c51a789e4c18fbbdf9/src/js/App/Header/UserToggle.js#L84-L93), and feel kinda robust to me :crossed_fingers: 
