### PR TITLE
User menu item text allow either "Logout" or "Log out"

### DIFF
--- a/lib/rules/web/ocm_console/cluster_list_page.xyaml
+++ b/lib/rules/web/ocm_console/cluster_list_page.xyaml
@@ -403,7 +403,7 @@ click_logout_button:
     op: click
   element:
     selector:
-      xpath: //button[@class='pf-c-dropdown__menu-item' and text()='Logout']
+      xpath: //button[@class='pf-c-dropdown__menu-item' and (text()='Logout' or text()='Log out')]
     op: click
     timeout: 20
 logout_page_loaded:


### PR DESCRIPTION
Changed in https://github.com/RedHatInsights/insights-chrome/pull/799
I still see "Logout" in prod, "Log out" in stage & dev.
Since Insights chrome is deployed somewhat orthogonally to OCM code, let's just allow both?